### PR TITLE
Dodaj admin stran z drag&drop urejanjem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-"# rabljenaSedla" 
+# Rabljena Sedla
+
+Ta repozitorij vsebuje preprosto spletno trgovino z rabljenimi in novimi sedli. Stran uporablja [Bootstrap](https://getbootstrap.com/) za hitro oblikovanje elementov.
+
+## Struktura projekta
+
+```
+website/
+  index.html       - domača stran s ponudbo sedel
+  about.html       - informacije o trgovini
+  contact.html     - kontaktni obrazec
+  admin.html       - preprosto orodje za urejanje ponudbe
+  assets/
+    style.css      - dodatni stili
+```
+
+## Uporaba
+
+Odprite `website/index.html` v brskalniku. V datoteki `index.html` lahko
+zamenjate povezave do slik in uredite opise sedel po svoji meri.
+
+Za urejanje sedel je na voljo stran `admin.html`. Dostop je zaščiten z enostavnim geslom `sedlo123`. Uporabite funkcijo povleci in spusti (drag & drop) za nalaganje slik in urejanje besedila, nato pa spremembe shranite. Podatki se shranijo v brskalnikovem `localStorage`.
+
+

--- a/website/about.html
+++ b/website/about.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="sl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>O nas - Rabljena Sedla</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container">
+            <a class="navbar-brand" href="index.html">Rabljena Sedla</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="mainNav">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item"><a class="nav-link" href="index.html">Domov</a></li>
+                    <li class="nav-item"><a class="nav-link active" href="about.html">O nas</a></li>
+                    <li class="nav-item"><a class="nav-link" href="contact.html">Kontakt</a></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <main class="container py-5">
+        <h1 class="mb-4">O nas</h1>
+        <p>Naša trgovina je specializirana za prodajo kakovostnih sedel, novih in rabljenih. Z dolgoletnimi izkušnjami vam pomagamo najti pravo sedlo za vaše potrebe.</p>
+    </main>
+
+    <footer class="bg-dark text-white text-center py-3 mt-4">
+        <p class="mb-0">&copy; 2024 Rabljena Sedla</p>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/website/admin.html
+++ b/website/admin.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="sl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Administracija - Rabljena Sedla</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+    <div id="login" class="container py-5">
+        <h1 class="mb-3">Vnos gesla</h1>
+        <p>Za dostop do urejanja vnesite geslo.</p>
+        <input type="password" id="pwd" class="form-control mb-2" placeholder="Geslo">
+        <button id="loginBtn" class="btn btn-primary">Prijava</button>
+    </div>
+
+    <div id="adminArea" class="container my-4" style="display:none;">
+        <h1 class="mb-4">Urejanje sedel</h1>
+        <div id="productList"></div>
+        <button id="addProductBtn" class="btn btn-success mt-3">Dodaj sedlo</button>
+        <button id="saveBtn" class="btn btn-primary mt-3 ms-2">Shrani</button>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+    const PASSWORD = 'sedlo123';
+
+    document.getElementById('loginBtn').addEventListener('click', () => {
+        if (document.getElementById('pwd').value === PASSWORD) {
+            document.getElementById('login').style.display = 'none';
+            document.getElementById('adminArea').style.display = 'block';
+            loadProducts();
+        } else {
+            alert('Napačno geslo');
+        }
+    });
+
+    function loadProducts() {
+        const stored = localStorage.getItem('sedla');
+        let products = stored ? JSON.parse(stored) : [];
+        const list = document.getElementById('productList');
+        list.innerHTML = '';
+        products.forEach((prod, i) => {
+            list.appendChild(createProductForm(prod));
+        });
+    }
+
+    function createProductForm(prod = {}) {
+        const div = document.createElement('div');
+        div.className = 'card mb-3 p-3';
+        div.innerHTML = `
+            <div class="row">
+                <div class="col-md-4">
+                    <div class="drop-zone border border-dashed text-center p-3">
+                        <img src="${prod.image || 'https://via.placeholder.com/400x300.png?text=Sedlo'}" class="img-fluid" alt="Sedlo">
+                        <p class="mt-2">Spusti sliko tukaj</p>
+                    </div>
+                </div>
+                <div class="col-md-8">
+                    <div class="mb-2">
+                        <label>Naslov</label>
+                        <input type="text" class="form-control title" value="${prod.title || ''}">
+                    </div>
+                    <div class="mb-2">
+                        <label>Opis</label>
+                        <textarea class="form-control desc" rows="2">${prod.desc || ''}</textarea>
+                    </div>
+                    <div class="mb-2">
+                        <label>Cena &euro;</label>
+                        <input type="number" class="form-control price" value="${prod.price || ''}">
+                    </div>
+                </div>
+            </div>`;
+        const dropZone = div.querySelector('.drop-zone');
+        const img = dropZone.querySelector('img');
+        dropZone.addEventListener('dragover', (e) => {
+            e.preventDefault();
+            dropZone.classList.add('bg-light');
+        });
+        dropZone.addEventListener('dragleave', () => {
+            dropZone.classList.remove('bg-light');
+        });
+        dropZone.addEventListener('drop', (e) => {
+            e.preventDefault();
+            dropZone.classList.remove('bg-light');
+            const file = e.dataTransfer.files[0];
+            if (file && file.type.startsWith('image/')) {
+                const reader = new FileReader();
+                reader.onload = () => { img.src = reader.result; };
+                reader.readAsDataURL(file);
+            }
+        });
+        return div;
+    }
+
+    document.getElementById('addProductBtn').addEventListener('click', () => {
+        document.getElementById('productList').appendChild(createProductForm());
+    });
+
+    document.getElementById('saveBtn').addEventListener('click', () => {
+        const products = [];
+        document.querySelectorAll('#productList .card').forEach(card => {
+            products.push({
+                image: card.querySelector('img').src,
+                title: card.querySelector('.title').value,
+                desc: card.querySelector('.desc').value,
+                price: card.querySelector('.price').value
+            });
+        });
+        localStorage.setItem('sedla', JSON.stringify(products));
+        alert('Shranjeno!');
+    });
+    </script>
+</body>
+</html>

--- a/website/assets/style.css
+++ b/website/assets/style.css
@@ -1,0 +1,18 @@
+body {
+    background-color: #f8f9fa;
+}
+.hero {
+    background-color: #efd5c2;
+}
+.price {
+    font-weight: bold;
+}
+
+.drop-zone {
+    cursor: pointer;
+    border: 2px dashed #6c757d;
+    position: relative;
+}
+.drop-zone.bg-light {
+    background-color: #f8f9fa;
+}

--- a/website/contact.html
+++ b/website/contact.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="sl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kontakt - Rabljena Sedla</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container">
+            <a class="navbar-brand" href="index.html">Rabljena Sedla</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="mainNav">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item"><a class="nav-link" href="index.html">Domov</a></li>
+                    <li class="nav-item"><a class="nav-link" href="about.html">O nas</a></li>
+                    <li class="nav-item"><a class="nav-link active" href="contact.html">Kontakt</a></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <main class="container py-5">
+        <h1 class="mb-4">Pišite nam</h1>
+        <form action="#" method="post" class="row g-3" novalidate>
+            <div class="col-md-6">
+                <label for="name" class="form-label">Ime</label>
+                <input type="text" id="name" name="name" class="form-control" required>
+            </div>
+            <div class="col-md-6">
+                <label for="email" class="form-label">E-pošta</label>
+                <input type="email" id="email" name="email" class="form-control" required>
+            </div>
+            <div class="col-12">
+                <label for="message" class="form-label">Sporočilo</label>
+                <textarea id="message" name="message" rows="5" class="form-control" required></textarea>
+            </div>
+            <div class="col-12">
+                <button type="submit" class="btn btn-primary">Pošlji</button>
+            </div>
+        </form>
+    </main>
+
+    <footer class="bg-dark text-white text-center py-3 mt-4">
+        <p class="mb-0">&copy; 2024 Rabljena Sedla</p>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="sl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Rabljena Sedla</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container">
+            <a class="navbar-brand" href="index.html">Rabljena Sedla</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="mainNav">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item"><a class="nav-link active" href="index.html">Domov</a></li>
+                    <li class="nav-item"><a class="nav-link" href="about.html">O nas</a></li>
+                    <li class="nav-item"><a class="nav-link" href="contact.html">Kontakt</a></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <main>
+        <section class="py-5 text-center bg-light">
+            <div class="container">
+                <h2 class="display-5">Dobrodošli na naši strani za prodajo sedel</h2>
+                <p class="lead">Izberite med kakovostnimi novimi in rabljenimi sedli.</p>
+            </div>
+        </section>
+
+        <section class="py-5">
+            <div class="container">
+                <h2 class="mb-4">Ponudba sedel</h2>
+                <div class="row g-3" id="products">
+                    <div class="col-md-4">
+                        <div class="card h-100">
+                            <img src="https://via.placeholder.com/400x300.png?text=Sedlo+1" class="card-img-top" alt="Sedlo 1">
+                            <div class="card-body text-center">
+                                <h3 class="card-title">Usnjeno sedlo</h3>
+                                <p class="card-text">Kakovostno usnje za udobno jahanje.</p>
+                            </div>
+                            <div class="card-footer text-center">
+                                <strong class="price">250 &euro;</strong>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="card h-100">
+                            <img src="https://via.placeholder.com/400x300.png?text=Sedlo+2" class="card-img-top" alt="Sedlo 2">
+                            <div class="card-body text-center">
+                                <h3 class="card-title">Tekmovalno sedlo</h3>
+                                <p class="card-text">Primerno za zahtevne jezdece.</p>
+                            </div>
+                            <div class="card-footer text-center">
+                                <strong class="price">350 &euro;</strong>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="card h-100">
+                            <img src="https://via.placeholder.com/400x300.png?text=Sedlo+3" class="card-img-top" alt="Sedlo 3">
+                            <div class="card-body text-center">
+                                <h3 class="card-title">Otroško sedlo</h3>
+                                <p class="card-text">Lahko in prilagojeno mladim jezdcem.</p>
+                            </div>
+                            <div class="card-footer text-center">
+                                <strong class="price">120 &euro;</strong>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="bg-dark text-white text-center py-3 mt-4">
+        <p class="mb-0">&copy; 2024 Rabljena Sedla</p>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const data = localStorage.getItem('sedla');
+            if (!data) return;
+            const products = JSON.parse(data);
+            const container = document.getElementById('products');
+            container.innerHTML = '';
+            products.forEach(prod => {
+                const col = document.createElement('div');
+                col.className = 'col-md-4';
+                col.innerHTML = `
+                    <div class="card h-100">
+                        <img src="${prod.image}" class="card-img-top" alt="Sedlo">
+                        <div class="card-body text-center">
+                            <h3 class="card-title">${prod.title}</h3>
+                            <p class="card-text">${prod.desc}</p>
+                        </div>
+                        <div class="card-footer text-center">
+                            <strong class="price">${prod.price} &euro;</strong>
+                        </div>
+                    </div>`;
+                container.appendChild(col);
+            });
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `admin.html` for editing saddle entries with a simple password prompt
- load products from `localStorage` on the homepage
- style the new drag-and-drop zone in the stylesheet
- document the admin page and password in the README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685ff24779d0832dac02aa8c8b6c94f1